### PR TITLE
change in dockerfile

### DIFF
--- a/dockerFile
+++ b/dockerFile
@@ -16,4 +16,4 @@ COPY . .
 EXPOSE 8000
 
 # Run the FastAPI application with Uvicorn
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "5000"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container startup to use port 5000 (previously 8000). The service still listens on all interfaces. If you run the app in containers, update exposed/mapped ports, ingress/load balancer rules, and health checks accordingly. For local access, use localhost:5000. No changes to user-facing functionality—this affects deployment/runtime configuration only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->